### PR TITLE
FIX HTTP 410 - API Gone

### DIFF
--- a/XamTwitch/XamTwitch.Android/CustomerRenderers/PlayerViewRenderer.cs
+++ b/XamTwitch/XamTwitch.Android/CustomerRenderers/PlayerViewRenderer.cs
@@ -36,21 +36,10 @@ namespace XamTwitch.Droid.CustomerRenderers
             {
                 _videoView = new VideoView(Context);
                 var relativeLayout = new ARelativeLayout(Context);
-                //var tmpControl = new TextView(Context)
-                //{
-                //    Text = "My Custom Video Player Here",
-                //    Background = new ColorDrawable(Android.Graphics.Color.Red),
-                //    TextSize = 64f,
-                //};
-                //relativeLayout.AddView(tmpControl);
                 relativeLayout.AddView(_videoView);
-
                 var layoutParams = new ARelativeLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
                 layoutParams.AddRule(LayoutRules.CenterInParent);
-                //tmpControl.LayoutParameters = layoutParams;
-
                 _videoView.LayoutParameters = layoutParams;
-
                 _mediaController = new MediaController(Context);
                 _mediaController.SetMediaPlayer(_videoView);
                 _videoView.SetMediaController(_mediaController);

--- a/XamTwitch/XamTwitch.iOS/Entitlements.plist
+++ b/XamTwitch/XamTwitch.iOS/Entitlements.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>com.mobcat.XamTwitch.xamarinessentials</string>
+    </array>
 </dict>
 </plist>
 

--- a/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
+++ b/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
@@ -28,7 +28,6 @@
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>

--- a/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
+++ b/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
@@ -27,6 +27,7 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -36,6 +37,7 @@
     <WarningLevel>4</WarningLevel>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>

--- a/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
+++ b/XamTwitch/XamTwitch.iOS/XamTwitch.iOS.csproj
@@ -24,10 +24,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
     <MtouchExtraArgs>-v -v -v -v</MtouchExtraArgs>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -51,6 +52,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>

--- a/XamTwitch/XamTwitch/Bootstrap.cs
+++ b/XamTwitch/XamTwitch/Bootstrap.cs
@@ -17,6 +17,7 @@ namespace XamTwitch
 
             ServiceContainer.Register<INavigationService>(navigationService);
             ServiceContainer.Register<ITwitchHttpService>(new TwitchHttpService());
+            ServiceContainer.Register<ITwitchAnonymousHttpService>(new TwitchAnonymousHttpService());
             ServiceContainer.Register<ITwitchPlaylistHttpService>(new TwitchPlaylistHttpService());
             ServiceContainer.Register<ITwitchAuthHttpService>(new TwitchAuthHttpService());
             platformSpecificBegin?.Invoke();

--- a/XamTwitch/XamTwitch/Constants.cs
+++ b/XamTwitch/XamTwitch/Constants.cs
@@ -1,18 +1,22 @@
 using System;
+
 namespace XamTwitch
 {
     public static class Constants
     {
-        public const string TwitchApiKey = "";
+        // Hardcoded anonymous ClientId used by Twitch
+        public const string TwitchAnonymousClientId = "kimne78kx3ncx6brgo4mv6wki5h1ko";
+
+        // dev.twitch.tv application settings
+        public const string TwitchApiKey = "<TWITCH_CLIENT_ID>";
         public const string TwitchApiUri = "https://api.twitch.tv/";
         public const string TwitchPlaylistApiUri = "https://usher.ttvnw.net/";
         public const string ClientIDHeaderKey = "Client-ID";
-
         public static string AppName = "XamTwitch";
 
         // OAuth
-        public static string iOSClientId = "";
-        public static string AndroidClientId = "";
+        public static string iOSClientId = "<TWITCH_CLIENT_ID>";
+        public static string AndroidClientId = "<TWITCH_CLIENT_ID>";
 
         // These values do not need changing
         public static string Scope = "user:read:email";

--- a/XamTwitch/XamTwitch/Constants.cs
+++ b/XamTwitch/XamTwitch/Constants.cs
@@ -4,9 +4,6 @@ namespace XamTwitch
 {
     public static class Constants
     {
-        // Hardcoded anonymous ClientId used by Twitch
-        public const string TwitchAnonymousClientId = "kimne78kx3ncx6brgo4mv6wki5h1ko";
-
         // dev.twitch.tv application settings
         public const string TwitchApiKey = "<TWITCH_CLIENT_ID>";
         public const string TwitchApiUri = "https://api.twitch.tv/";

--- a/XamTwitch/XamTwitch/Helpers/TaskHelper.cs
+++ b/XamTwitch/XamTwitch/Helpers/TaskHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace XamTwitch.Helpers
+{
+    public static class TaskHelper
+    {
+        public static void HandleResult(this Task source)
+        {
+            if (source == null)
+                return;
+
+            source.ContinueWith(r =>
+            {
+                var ex = r.Exception?.Flatten();
+                System.Diagnostics.Debug.WriteLine(ex);
+                Microsoft.MobCAT.Logger.Error(ex);
+            }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+    }
+}

--- a/XamTwitch/XamTwitch/Services/ITwitchAnonymousHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/ITwitchAnonymousHttpService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using XamTwitch.Models;
+
+namespace XamTwitch.Services
+{
+    public interface ITwitchAnonymousHttpService
+    {
+        Task<TwitchToken> GetTwitchTokenAsync(string userName);
+    }
+}

--- a/XamTwitch/XamTwitch/Services/ITwitchHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/ITwitchHttpService.cs
@@ -8,6 +8,5 @@ namespace XamTwitch.Services
     {
         Task<TwitchGames> GetTwitchGamesAsync(string gameName);
         Task<TwitchStreams> GetTwitchStreamsAsync();
-        Task<TwitchToken> GetTwitchTokenAsync(string userName);
     }
 }

--- a/XamTwitch/XamTwitch/Services/TwitchAnonymousHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/TwitchAnonymousHttpService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.MobCAT.Services;
 using XamTwitch.Helpers;
@@ -9,10 +10,10 @@ namespace XamTwitch.Services
 {
     public class TwitchAnonymousHttpService : BaseHttpService, ITwitchAnonymousHttpService
     {
-        public TwitchAnonymousHttpService() : base(Constants.TwitchApiUri, handler: null)
+        private string _anonymousClientId = null;
+
+        public TwitchAnonymousHttpService() : base(null, handler: null)
         {
-            SetDefaultRequestHeaders(shouldClear: false,
-                headers: new KeyValuePair<string, string>(Constants.ClientIDHeaderKey, Constants.TwitchAnonymousClientId));
             Serializer = new NewtonsoftJsonSerializer();
         }
 
@@ -23,10 +24,35 @@ namespace XamTwitch.Services
                 throw new ArgumentException(nameof(userName));
             }
 
+            await SetAnonymousClientId(userName);
+
             var channelName = userName.ToLower();
-            var url = $"api/channels/{channelName}/access_token";
+            var url = $"{Constants.TwitchApiUri}api/channels/{channelName}/access_token";
             var token = await GetAsync<TwitchToken>(url);
             return token;
+        }
+
+        private async Task SetAnonymousClientId(string userName)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentException(nameof(userName));
+            }
+
+            if (!string.IsNullOrWhiteSpace(_anonymousClientId))
+            {
+                return;
+            }
+
+            var playerHtmlUrl = $"https://player.twitch.tv/?channel={userName}";
+            var playerResponse = await GetAsync<string>(playerHtmlUrl, deserializeResponse: false);
+            var playerJS = Regex.Match(playerResponse, @"src=""(?<playerJS>js/video.\w+.js)""").Groups["playerJS"].Value;
+            var playerJSUrl = $"https://player.twitch.tv/{playerJS}";
+            var playerJSResponse = await GetAsync<string>(playerJSUrl, deserializeResponse: false);
+            _anonymousClientId = Regex.Match(playerJSResponse, @"{""Client-ID"":""(?<clientId>[^""]+)""").Groups["clientId"].Value;
+            SetDefaultRequestHeaders(shouldClear: true, headers: new KeyValuePair<string, string>(Constants.ClientIDHeaderKey, _anonymousClientId));
+
+            System.Diagnostics.Debug.WriteLine($"Anonymous client id fetched and set: {_anonymousClientId}");
         }
     }
 }

--- a/XamTwitch/XamTwitch/Services/TwitchAnonymousHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/TwitchAnonymousHttpService.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.MobCAT.Services;
+using XamTwitch.Helpers;
+using XamTwitch.Models;
+
+namespace XamTwitch.Services
+{
+    public class TwitchAnonymousHttpService : BaseHttpService, ITwitchAnonymousHttpService
+    {
+        public TwitchAnonymousHttpService() : base(Constants.TwitchApiUri, handler: null)
+        {
+            SetDefaultRequestHeaders(shouldClear: false,
+                headers: new KeyValuePair<string, string>(Constants.ClientIDHeaderKey, Constants.TwitchAnonymousClientId));
+            Serializer = new NewtonsoftJsonSerializer();
+        }
+
+        public async Task<TwitchToken> GetTwitchTokenAsync(string userName)
+        {
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new ArgumentException(nameof(userName));
+            }
+
+            var channelName = userName.ToLower();
+            var url = $"api/channels/{channelName}/access_token";
+            var token = await GetAsync<TwitchToken>(url);
+            return token;
+        }
+    }
+}

--- a/XamTwitch/XamTwitch/Services/TwitchHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/TwitchHttpService.cs
@@ -1,12 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MobCAT.Services;
-using Newtonsoft.Json;
-using Xamarin.Essentials;
 using XamTwitch.Helpers;
 using XamTwitch.Models;
 
@@ -29,20 +24,6 @@ namespace XamTwitch.Services
         public Task<TwitchStreams> GetTwitchStreamsAsync()
         {
             return GetAsync<TwitchStreams>($"helix/streams");
-        }
-
-        public async Task<TwitchToken> GetTwitchTokenAsync(string userName)
-        {
-            if (string.IsNullOrWhiteSpace(userName))
-            {
-                throw new ArgumentException(nameof(userName));
-            }
-
-            System.Diagnostics.Debug.WriteLine($"{Thread.CurrentThread.ManagedThreadId}, IsMain: {MainThread.IsMainThread}");
-            var channelName = userName.ToLower();
-            var url = $"api/channels/{channelName}/access_token";
-            var token = await GetAsync<TwitchToken>(url);
-            return token;
         }
     }
 }

--- a/XamTwitch/XamTwitch/Services/TwitchPlaylistHttpService.cs
+++ b/XamTwitch/XamTwitch/Services/TwitchPlaylistHttpService.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.MobCAT.Services;
-using XamTwitch.Helpers;
 using XamTwitch.Models;
 
 namespace XamTwitch.Services
@@ -16,7 +14,7 @@ namespace XamTwitch.Services
         {
             Serializer = new TwitchPlaylistSerializer();
         }
-        
+
         public async Task<string> GetPlaylistUriAsync(string userName, TwitchToken token)
         {
             if (string.IsNullOrWhiteSpace(userName) || token == null ||  string.IsNullOrWhiteSpace(token.Sig) || string.IsNullOrWhiteSpace(token.Token))

--- a/XamTwitch/XamTwitch/ViewModels/DiscoverPageViewModel.cs
+++ b/XamTwitch/XamTwitch/ViewModels/DiscoverPageViewModel.cs
@@ -41,7 +41,7 @@ namespace XamTwitch.ViewModels
 
         public override async Task InitAsync()
         {
-            var gamesResult = await _twitchHttpService.GetTwitchStreamsAsync().ConfigureAwait(false);
+            var gamesResult = await _twitchHttpService.GetTwitchStreamsAsync();
             Streams = new ObservableCollection<TwitchStream>(gamesResult.Data);
         }
     }

--- a/XamTwitch/XamTwitch/ViewModels/PlayerPageViewModel.cs
+++ b/XamTwitch/XamTwitch/ViewModels/PlayerPageViewModel.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Net.Http;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.MobCAT;
 using Microsoft.MobCAT.MVVM;
-using Newtonsoft.Json;
-using Xamarin.Essentials;
 using XamTwitch.Helpers;
 using XamTwitch.Models;
 using XamTwitch.Services;
@@ -15,7 +10,7 @@ namespace XamTwitch.ViewModels
 {
     public class PlayerPageViewModel : BaseNavigationViewModel
     {
-        private readonly ITwitchHttpService _twitchHttpService;
+        private readonly ITwitchAnonymousHttpService _twitchAnonymousHttpService;
         private readonly ITwitchPlaylistHttpService _twitchPlaylistHttpService;
 
         private TwitchStream _stream;
@@ -40,7 +35,7 @@ namespace XamTwitch.ViewModels
 
         public PlayerPageViewModel()
         {
-            _twitchHttpService = ServiceContainer.Resolve<ITwitchHttpService>();
+            _twitchAnonymousHttpService = ServiceContainer.Resolve<ITwitchAnonymousHttpService>();
             _twitchPlaylistHttpService = ServiceContainer.Resolve<ITwitchPlaylistHttpService>();
         }
 
@@ -49,7 +44,7 @@ namespace XamTwitch.ViewModels
             if (Stream == null)
                 return;
 
-            var token = await _twitchHttpService.GetTwitchTokenAsync(Stream.UserName);
+            var token = await _twitchAnonymousHttpService.GetTwitchTokenAsync(Stream.UserName);
             var streamUrl = await _twitchPlaylistHttpService.GetPlaylistUriAsync(Stream.UserName, token);
             StreamSource = streamUrl;
         }

--- a/XamTwitch/XamTwitch/ViewModels/PlayerPageViewModel.cs
+++ b/XamTwitch/XamTwitch/ViewModels/PlayerPageViewModel.cs
@@ -7,6 +7,7 @@ using Microsoft.MobCAT;
 using Microsoft.MobCAT.MVVM;
 using Newtonsoft.Json;
 using Xamarin.Essentials;
+using XamTwitch.Helpers;
 using XamTwitch.Models;
 using XamTwitch.Services;
 
@@ -25,7 +26,7 @@ namespace XamTwitch.ViewModels
             {
                 if(RaiseAndUpdate(ref _stream, value))
                 {
-                    FetchTwitchStreamAsync();
+                    FetchTwitchStreamAsync().HandleResult();
                 }
             }
         }
@@ -45,20 +46,12 @@ namespace XamTwitch.ViewModels
 
         private async Task FetchTwitchStreamAsync()
         {
-            try
-            {
-                if (Stream == null)
-                    return;
+            if (Stream == null)
+                return;
 
-                var token = await _twitchHttpService.GetTwitchTokenAsync(Stream.UserName);
-                var streamUrl = await _twitchPlaylistHttpService.GetPlaylistUriAsync(Stream.UserName, token);
-                StreamSource = streamUrl;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(ex);
-                throw;
-            }
+            var token = await _twitchHttpService.GetTwitchTokenAsync(Stream.UserName);
+            var streamUrl = await _twitchPlaylistHttpService.GetPlaylistUriAsync(Stream.UserName, token);
+            StreamSource = streamUrl;
         }
     }
 }

--- a/build/pr-check.yml
+++ b/build/pr-check.yml
@@ -103,6 +103,11 @@ stages:
         restoreSolution: 'XamTwitch/XamTwitch.sln'
         feedsToUse: 'config'
         nugetConfigPath: 'build/Nuget.config'
+
+    - task: InstallAppleProvisioningProfile@1
+      inputs:
+        provisioningProfileLocation: 'secureFiles'
+        provProfileSecureFile: 'VS_WildCard_Development.mobileprovision'
         
     - task: MSBuild@1
       displayName: 'Build  Xamarin.iOS App'


### PR DESCRIPTION
This PR restores ability of the app to stream and also includes the following fixes:

1. fix http error 410 - API Gone -> switch to anonymous client id and additional undocumented API
1. fix inability to playback videos on ios, now the player details page plays videos reliably
1. fix unwanted `configureawait`, execute all async methods with a continuation
1. implement anonymous client http service which acts on behalf of an anonymous user and fetches required data about channels and active streams/playlists.
1. add missing keychain entitlements for ios secure storage (xam.essentials)
1. code cleanup

![Simulator Screen Shot - iPhone 11 - 2020-01-10 at 14 59 51](https://user-images.githubusercontent.com/3697084/72197296-8b37e180-33d4-11ea-98c9-0573bc3d1d23.png)
